### PR TITLE
Update dependencies and GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn --batch-mode --update-snapshots install
       - name: Setup npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '>=18.17.0'
       - name: Install redocly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
 
       # first checkout your code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn --batch-mode --update-snapshots install
       - name: Setup npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '>=18.17.0'
       - name: Install redocly
@@ -73,7 +73,7 @@ jobs:
           cp ./CNAME ../docs
           cp ./.nojekyll ../docs
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
       - name: Copy back

--- a/.github/workflows/publish_docker_3key.yaml
+++ b/.github/workflows/publish_docker_3key.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.10.0
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_docker_czertainly.yaml
+++ b/.github/workflows/publish_docker_czertainly.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.10.0
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_harbor_3key.yaml
+++ b/.github/workflows/publish_harbor_3key.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.10.0
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM maven:3.9.9-eclipse-temurin-21 as build
+FROM maven:3.9.11-eclipse-temurin-21 as build
 COPY ./ /home/app
 COPY settings.xml /root/.m2/settings.xml
 RUN mvn -f /home/app/pom.xml clean verify

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <!-- Our Custom CSS -->
   <link rel="stylesheet" href="style.css">
   <!-- Font Awesome CDN -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/font-awesome.min.css">
 </head>
 <body scroll="no" style="overflow: hidden;">
 <div class="wrapper">

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.czertainly</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>doc-interface</artifactId>
@@ -18,9 +18,9 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <revision>2.16.0</revision>
-        <apiVersion>2.16.0</apiVersion>
-        <springdocOpenapiMavenPluginVersion>1.4</springdocOpenapiMavenPluginVersion>
+        <revision>2.16.1-SNAPSHOT</revision>
+        <apiVersion>2.16.1-SNAPSHOT</apiVersion>
+        <springdocOpenapiMavenPluginVersion>1.5</springdocOpenapiMavenPluginVersion>
     </properties>
 
     <repositories>
@@ -91,7 +91,13 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-common</artifactId>
+            <version>2.8.14</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- upgraded GitHub Actions to latest versions (checkout v5, setup-java v5, setup-node v6, cosign-installer v4.0.0) across workflows
- updated Dockerfile to use Maven 3.9.11
- bumped parent Dependencies  to 1.3.1
- including springdoc-openapi to 2.8.14 and related plugin versions.
- updated Font Awesome CDN in index.html to 7.0.1.