### PR TITLE
Bump interfaces to 2.17.1-SNAPSHOT for asynchronous authority operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <revision>2.17.0</revision>
-        <apiVersion>2.17.0</apiVersion>
+        <revision>2.17.1-SNAPSHOT</revision>
+        <apiVersion>2.17.1-SNAPSHOT</apiVersion>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>


### PR DESCRIPTION
## Summary

- Bump `apiVersion` and `revision` from `2.17.0` to `2.17.1-SNAPSHOT` so the regenerated OpenAPI documents reflect the asynchronous authority provider operations contract merged into `interfaces`.
- The newly surfaced surface includes the operator endpoints `manuallyIssueCertificate`, `manuallyConfirmRevoke`, `cancelPendingCertificateOperation`, the `UploadCertificateRequestDto` and `CancelPendingCertificateRequestDto` schemas, the connector-side `/v2/authorityProvider/.../certificates/issue/cancel` and `revoke/cancel` endpoints, and the new `pending_issue` / `pending_revoke` values in `CertificateState`.
- No `groups.yaml` changes required: the contract additions sit inside controllers already registered (`core.client.v2.ClientOperationController` and `connector.v2.CertificateController`), and the generator picks new methods up automatically.

## Test plan

- [x] Local clean install regenerates OpenAPI YAMLs against `2.17.1-SNAPSHOT` without error.
- [x] Regenerated YAMLs contain `manuallyIssueCertificate`, `manuallyConfirmRevoke`, `cancelPendingCertificateOperation`, `UploadCertificateRequestDto`, `CancelPendingCertificateRequestDto`, the connector cancel endpoints, and the `pending_issue`/`pending_revoke` enum values.
- [x] CI build resolves `com.czertainly:interfaces:2.17.1-SNAPSHOT` from the configured snapshot repository.
- [x] CI lint passes for regenerated documents.
- [x] CI bundle step renders the updated docs successfully.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
