### PR TITLE
Add Proxy, Time Quality, Trusted Certificate, and TSP Profile APIs

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -407,6 +407,14 @@ groups:
       - com.czertainly.api.interfaces.core.web.SettingController
       - com.czertainly.api.interfaces.core.web.StatisticsController
 
+  - id: doc-openapi-core-proxy
+    groupName: core-proxy
+    title: Proxy API
+    indexCategory: core
+    description: REST API for managing Proxies in the platform
+    interfaces:
+      - com.czertainly.api.interfaces.core.web.ProxyController
+
   - id: doc-openapi-core-ra-profile
     groupName: core-ra-profile
     title: RA Profile API
@@ -439,6 +447,14 @@ groups:
     interfaces:
       - com.czertainly.api.interfaces.core.web.SecretManagementController
 
+  - id: doc-openapi-core-time-quality-configuration
+    groupName: core-time-quality-configuration
+    title: Time Quality Configuration API
+    indexCategory: core
+    description: REST API for managing Time Quality Configurations in the platform
+    interfaces:
+      - com.czertainly.api.interfaces.core.web.TimeQualityConfigurationController
+
   - id: doc-openapi-core-token
     groupName: core-token
     title: Token Management API
@@ -455,6 +471,22 @@ groups:
     description: REST API for managing Token Profiles in the platform
     interfaces:
       - com.czertainly.api.interfaces.core.web.TokenProfileController
+
+  - id: doc-openapi-core-trusted-certificate
+    groupName: core-trusted-certificate
+    title: Trusted Certificate API
+    indexCategory: core
+    description: REST API for managing Trusted Certificates in the platform
+    interfaces:
+      - com.czertainly.api.interfaces.core.web.TrustedCertificateController
+
+  - id: doc-openapi-core-tsp-profile
+    groupName: core-tsp-profile
+    title: TSP Profile API
+    indexCategory: core
+    description: REST API for managing TSP (Timestamping Protocol) Profiles in the platform
+    interfaces:
+      - com.czertainly.api.interfaces.core.web.TspProfileController
 
   - id: doc-openapi-core-vault
     groupName: core-vault
@@ -521,6 +553,7 @@ groups:
       - com.czertainly.api.interfaces.core.web.NotificationController
       - com.czertainly.api.interfaces.core.web.NotificationInstanceController
       - com.czertainly.api.interfaces.core.web.NotificationProfileController
+      - com.czertainly.api.interfaces.core.web.ProxyController
       - com.czertainly.api.interfaces.core.web.RAProfileManagementController
       - com.czertainly.api.interfaces.core.web.ResourceController
       - com.czertainly.api.interfaces.core.web.RoleManagementController
@@ -530,9 +563,12 @@ groups:
       - com.czertainly.api.interfaces.core.web.SecretManagementController
       - com.czertainly.api.interfaces.core.web.SettingController
       - com.czertainly.api.interfaces.core.web.StatisticsController
+      - com.czertainly.api.interfaces.core.web.TimeQualityConfigurationController
       - com.czertainly.api.interfaces.core.web.TokenInstanceController
       - com.czertainly.api.interfaces.core.web.TokenProfileController
       - com.czertainly.api.interfaces.core.web.TriggerController
+      - com.czertainly.api.interfaces.core.web.TrustedCertificateController
+      - com.czertainly.api.interfaces.core.web.TspProfileController
       - com.czertainly.api.interfaces.core.web.UserManagementController
       - com.czertainly.api.interfaces.core.web.VaultInstanceController
       - com.czertainly.api.interfaces.core.web.VaultProfileController


### PR DESCRIPTION
## Summary

Four authority/management controllers were added to interfaces in recent PRs (the SaaS migration plus #194 / #196 / #663) but were never referenced in \`groups.yaml\` — so the regenerated OpenAPI YAMLs did not include their endpoints, and consumers (most visibly fe-administrator) could not generate the corresponding API client classes (\`ProxyManagementApi\`, \`TrustedCertificateManagementApi\`, \`TimeQualityConfigurationManagementApi\`, \`TspProfileManagementApi\`).

Each new controller gets its own dedicated \`doc-openapi-core-*\` group following the established one-controller-per-group pattern, and is also added alphabetically to the umbrella \`doc-openapi-ilm-core\` interfaces list — that umbrella YAML is what fe-administrator's openapi-generator consumes.

## Why now

\`doc-openapi-core-proxy.yaml\` previously failed redocly's \`no-required-schema-properties-undefined\` rule due to a circular schema reference between \`ProxyDto.connectors\` and \`ConnectorDto\`. That cycle was structurally broken in [interfaces#669](https://github.com/OmniTrustILM/interfaces/pull/669) (merged) by narrowing \`ProxyDto.connectors\` items to a new \`ConnectorSummaryDto\`. With the cycle gone, the dedicated proxy group lints cleanly and can be safely added.

## Test plan

- [x] \`mvn install\` regenerates all 51 OpenAPI YAMLs against the latest \`2.17.1-SNAPSHOT\`.
- [x] \`./lint.sh\` exits 0 across all 51 YAMLs (redocly-cli 2.30.3, matching CI).
- [x] \`Proxy Management\`, \`Trusted Certificate Management\`, \`Time Quality Configuration Management\`, and \`TSP Profile Management\` tags now present in both their dedicated YAMLs and \`doc-openapi-ilm-core.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)