### PR TITLE
Fix lint errors for security schemes in core OpenAPI docs

### DIFF
--- a/openapi-generator/src/main/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilder.java
+++ b/openapi-generator/src/main/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilder.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -168,9 +169,11 @@ public class GroupedOpenApiBuilder {
         // Set document-level security
         openApi.setSecurity(securityRequirements.isEmpty() ? new ArrayList<>() : securityRequirements);
 
-        // If security is empty (security: []), remove all operation-level security
+        // If security is empty (security: []), remove all operation-level security and
+        // strip orphan security scheme definitions from components (they have no references).
         if (securityRequirements.isEmpty()) {
             removeAllOperationSecurity(openApi);
+            openApiSecuritySanitizer.sanitizeSecuritySchemes(openApi, Collections.emptySet());
             log.info("Applied explicit empty security ([]) for group {}", groupConfig.getGroupName());
         } else {
             log.info("Applied explicit security requirements for group {}: {}",

--- a/openapi-generator/src/main/java/com/otilm/openapi/config/security/OpenApiSecuritySanitizer.java
+++ b/openapi-generator/src/main/java/com/otilm/openapi/config/security/OpenApiSecuritySanitizer.java
@@ -50,9 +50,15 @@ public class OpenApiSecuritySanitizer {
 
         // 2. Remove references from global security
         if (openApi.getSecurity() != null) {
+            boolean originallyEmpty = openApi.getSecurity().isEmpty();
             var filteredGlobalSecurity = new ArrayList<>(openApi.getSecurity());
             filteredGlobalSecurity.removeIf(secReq -> !isValidSecurityRequirement(secReq, validSchemes));
-            openApi.setSecurity(filteredGlobalSecurity.isEmpty() ? null : filteredGlobalSecurity);
+            // Preserve explicit security: [] — same semantics as operation-level handling above.
+            if (filteredGlobalSecurity.isEmpty() && !originallyEmpty) {
+                openApi.setSecurity(null);
+            } else {
+                openApi.setSecurity(filteredGlobalSecurity);
+            }
         }
 
         // 3. Remove references to deleted schemes from all operations

--- a/openapi-generator/src/test/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilderTest.java
+++ b/openapi-generator/src/test/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilderTest.java
@@ -93,8 +93,51 @@ class GroupedOpenApiBuilderTest {
         Operation getOperation = openApi.getPaths().get("/v1/test").getGet();
         assertNull(getOperation.getSecurity(), "Operation-level security should be removed when document-level is []");
 
-        // And: Sanitizer should NOT be called (explicit security bypasses it)
-        verify(openApiSecuritySanitizer, never()).sanitizeSecuritySchemes(any(), any());
+        // And: Sanitizer is called with empty set to strip orphan security scheme components
+        verify(openApiSecuritySanitizer, times(1)).sanitizeSecuritySchemes(eq(openApi), eq(Collections.emptySet()));
+    }
+
+    @Test
+    void shouldStripSecuritySchemeComponentsWhenEmptySecurityConfigured() {
+        // End-to-end with real sanitizer: security: [] removes orphan scheme definitions
+        // AND preserves root security: [] (required by the security-defined lint rule).
+        GroupedOpenApiBuilder realSanitizerBuilder = new GroupedOpenApiBuilder(
+                infoBuilder, securitySchemeMetadataReader, new OpenApiSecuritySanitizer(), "1.0.0");
+
+        GroupConfiguration groupConfig = new GroupConfiguration();
+        groupConfig.setId("test-group");
+        groupConfig.setGroupName("test");
+        groupConfig.setTitle("Test API");
+        groupConfig.setDescription("Test Description");
+        groupConfig.setInterfaces(new ArrayList<>(List.of("com.example.TestController")));
+        groupConfig.setSecurity(Collections.emptyList());
+
+        OpenAPI openApi = new OpenAPI()
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("BearerJWTAuth", new io.swagger.v3.oas.models.security.SecurityScheme())
+                        .addSecuritySchemes("SessionAuth", new io.swagger.v3.oas.models.security.SecurityScheme()))
+                .paths(new Paths()
+                        .addPathItem("/v1/test", new PathItem()
+                                .get(new Operation()
+                                        .addSecurityItem(new SecurityRequirement().addList("BearerJWTAuth")))));
+
+        when(infoBuilder.buildInfo(anyString(), anyString(), anyString(), any())).thenReturn(new io.swagger.v3.oas.models.info.Info());
+        doNothing().when(infoBuilder).addCommonElements(any(), any(), any());
+
+        try {
+            var m = GroupedOpenApiBuilder.class.getDeclaredMethod(
+                    "customizeOpenApi", OpenAPI.class, GroupConfiguration.class, CommonConfiguration.class);
+            m.setAccessible(true);
+            m.invoke(realSanitizerBuilder, openApi, groupConfig, new CommonConfiguration());
+        } catch (Exception e) {
+            fail("Failed to invoke customizeOpenApi: " + e.getMessage());
+        }
+
+        assertNull(openApi.getComponents().getSecuritySchemes(),
+                "security: [] must strip all security scheme definitions from components");
+        assertNotNull(openApi.getSecurity(),
+                "Root security: [] must not be nullified (required by security-defined lint rule)");
+        assertTrue(openApi.getSecurity().isEmpty(), "Root security must remain an empty list");
     }
 
     @Test

--- a/openapi-generator/src/test/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilderTest.java
+++ b/openapi-generator/src/test/java/com/otilm/openapi/config/builder/GroupedOpenApiBuilderTest.java
@@ -130,7 +130,7 @@ class GroupedOpenApiBuilderTest {
             m.setAccessible(true);
             m.invoke(realSanitizerBuilder, openApi, groupConfig, new CommonConfiguration());
         } catch (Exception e) {
-            fail("Failed to invoke customizeOpenApi: " + e.getMessage());
+            fail("Failed to invoke customizeOpenApi", e);
         }
 
         assertNull(openApi.getComponents().getSecuritySchemes(),

--- a/openapi-generator/src/test/java/com/otilm/openapi/config/security/OpenApiSecuritySanitizerTest.java
+++ b/openapi-generator/src/test/java/com/otilm/openapi/config/security/OpenApiSecuritySanitizerTest.java
@@ -59,6 +59,30 @@ class OpenApiSecuritySanitizerTest {
     }
 
     @Test
+    void shouldPreserveExplicitlyEmptyGlobalSecurity() {
+        // Global security: [] means "no auth required" — must not be nullified,
+        // unlike a list that had all its schemes filtered out.
+        OpenAPI openApi = new OpenAPI().security(List.of());
+
+        sanitizer.sanitizeSecuritySchemes(openApi, Set.of());
+
+        assertNotNull(openApi.getSecurity(), "Explicit root security: [] must not be removed");
+        assertTrue(openApi.getSecurity().isEmpty(), "Root security must remain an empty list");
+    }
+
+    @Test
+    void shouldNullifyGlobalSecurityWhenAllSchemesFilteredOut() {
+        // A non-empty security list whose schemes are all removed must be nullified (not preserved).
+        OpenAPI openApi = new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList("RemovedScheme"));
+
+        sanitizer.sanitizeSecuritySchemes(openApi, Set.of());
+
+        assertNull(openApi.getSecurity(),
+                "Global security referencing only removed schemes must be nullified");
+    }
+
+    @Test
     void shouldRemovePreExistingEmptySecuritySchemesMap() {
         OpenAPI openApi = new OpenAPI()
                 .components(new Components()


### PR DESCRIPTION
## Summary

- **Root cause:** Groups configured with `security: []` (e.g. `czertainly-core` / `doc-openapi-ilm-core`) had all security requirements stripped from operations, but security scheme definitions remained in `components/securitySchemes` unreferenced. Redocly CLI 2.31.5 started enforcing the `no-unused-components` rule for security schemes, surfacing this as 7 errors.
- **Fix 1 (`GroupedOpenApiBuilder`):** When `security: []` is configured, also call `sanitizeSecuritySchemes(emptySet)` to remove orphan scheme definitions from components — making the implementation match the intent already documented in `groups.yaml`.
- **Fix 2 (`OpenApiSecuritySanitizer`):** Preserve an explicit root-level `security: []` instead of nullifying it (mirrors the existing operation-level logic), preventing a follow-on `security-defined` rule violation that would otherwise surface.

## Changed files

| File | Change |
|---|---|
| `GroupedOpenApiBuilder.java` | Call `sanitizeSecuritySchemes(emptySet)` in the `security: []` branch of `applyExplicitSecurity` |
| `OpenApiSecuritySanitizer.java` | Add `originallyEmpty` guard to global security filtering, symmetric with the existing operation-level guard |
| `GroupedOpenApiBuilderTest.java` | Update mock assertion; add end-to-end integration test with real sanitizer covering both invariants |
| `OpenApiSecuritySanitizerTest.java` | Add `shouldPreserveExplicitlyEmptyGlobalSecurity` and `shouldNullifyGlobalSecurityWhenAllSchemesFilteredOut` |

## Test plan

- [ ] All 23 unit tests pass (`mvn -pl openapi-generator -am test`)
- [ ] CI linting passes with Redocly CLI 2.31.5 (`no-unused-components` errors resolved, `security-defined` rule not triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)