### PR TITLE
Add Attributes v2 API to connector v2 documentation groups

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -110,6 +110,7 @@ groups:
     extensions:
       x-metrics-profile: "`com.otilm.api.interfaces.connector.common.v2.MetricsController.METRICS_CONFIG`"
     interfaces:
+      - com.otilm.api.interfaces.connector.common.v2.AttributesController
       - com.otilm.api.interfaces.connector.common.v2.HealthController
       - com.otilm.api.interfaces.connector.common.v2.InfoController
       - com.otilm.api.interfaces.connector.common.v2.MetricsController
@@ -213,6 +214,7 @@ groups:
     extensions:
       x-metrics-profile: "`com.otilm.api.interfaces.connector.common.v2.MetricsController.METRICS_CONFIG`"
     interfaces:
+      - com.otilm.api.interfaces.connector.common.v2.AttributesController
       - com.otilm.api.interfaces.connector.common.v2.HealthController
       - com.otilm.api.interfaces.connector.common.v2.InfoController
       - com.otilm.api.interfaces.connector.common.v2.MetricsController
@@ -228,6 +230,7 @@ groups:
     extensions:
       x-metrics-profile: "`com.otilm.api.interfaces.connector.common.v2.MetricsController.METRICS_CONFIG`"
     interfaces:
+      - com.otilm.api.interfaces.connector.common.v2.AttributesController
       - com.otilm.api.interfaces.connector.common.v2.HealthController
       - com.otilm.api.interfaces.connector.common.v2.InfoController
       - com.otilm.api.interfaces.connector.common.v2.MetricsController


### PR DESCRIPTION
Adds `com.otilm.api.interfaces.connector.common.v2.AttributesController` to every connector group built on the `connector.common.v2` (NG) framework, so the generated `openapi/*.yaml` expose the `/v2/attributes` definition registry, callback envelope, definition-registry DTOs, and the `ATTRIBUTE_DEFINITION_NOT_FOUND` error.

## Groups updated
- `doc-openapi-connector-authority-provider-v3`
- `doc-openapi-connector-secret-provider`
- `doc-openapi-connector-signature-formatting-provider`

> **Note:** The issue body enumerates only the first two. `doc-openapi-connector-signature-formatting-provider` also builds on `connector.common.v2` (it lists the common.v2 Health/Info/Metrics controllers), so it is included per the DoD catch-all: *"Any other connector group built on `connector.common.v2` lists the Attributes v2 API controller."* Confirmed as intentional — the signature-formatting connector was not available when ilm#251 was written; as an NG connector it carries the Attributes v2 API like the others.

## Verification
`mvn clean verify -Dmaven.compiler.proc=full` — **BUILD SUCCESS**, all tests pass (incl. `EndToEndIT` 12/12). Generated docs for all three groups now contain:
- `/v2/attributes`, `/v2/attributes/callback`, `/v2/attributes/{uuid}`
- callback envelope (`AttributeCallbackRequestDto` / `AttributeCallbackResponseDto`)
- definition-registry DTOs (`AttributeDefinitionsDto`, `listDefinitions` / `getDefinition`)
- `ATTRIBUTE_DEFINITION_NOT_FOUND` error
- portal nav (`index.html`) regenerated with the updated connector groups

`openapi/*.yaml` and `index.html` are build artifacts (gitignored, generated in CI/Docker); the only source change is `groups.yaml`.

Related to the Attributes v2 provider interface API epic (ilm#251).

## Follow-up connector issues
Connector-side implementation tracked under ilm#251:
- OmniTrustILM/otpki-connector#25 (Authority Provider v3)
- OmniTrustILM/hashicorp-vault-connector#127 (Secret Provider)
- OmniTrustILM/common-credential-provider#84 (Secret Provider, NG)
- OmniTrustILM/timestamp-formatting-connector#41 (Signature Formatter)

Closes #211