### PR TITLE
Publish the branding API in the core OpenAPI groups

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -433,6 +433,7 @@ groups:
     description: Various uncategorized REST APIs of the platform
     interfaces:
       - com.otilm.api.interfaces.core.web.AuditLogController
+      - com.otilm.api.interfaces.core.web.BrandingController
       - com.otilm.api.interfaces.core.web.CbomController
       - com.otilm.api.interfaces.core.web.CustomOidEntryController
       - com.otilm.api.interfaces.core.web.EnumController
@@ -583,6 +584,7 @@ groups:
       - com.otilm.api.interfaces.core.web.AuditLogController
       - com.otilm.api.interfaces.core.web.AuthController
       - com.otilm.api.interfaces.core.web.AuthorityInstanceController
+      - com.otilm.api.interfaces.core.web.BrandingController
       - com.otilm.api.interfaces.core.web.CallbackController
       - com.otilm.api.interfaces.core.web.CbomController
       - com.otilm.api.interfaces.core.web.CertificateController


### PR DESCRIPTION
Companion to OmniTrustILM/interfaces#868 (OmniTrustILM/interfaces#866).

`BrandingController` is the unauthenticated `GET /v1/branding` endpoint that lets the login page render in the operator's colours before anyone has signed in. Controllers are listed per group by hand, so without an entry here the path never reaches a generated document.

The *schemas* would have appeared anyway — `BrandingSettingsDto` and friends arrive through `SettingController`'s `PlatformSettingsDto`. It is the endpoint serving them that goes missing, which would leave the frontend with types but no client for the one call it makes before authenticating.

Added to both groups that already carry `SettingController`, in the alphabetical position each list keeps:
- `doc-openapi-core-other` — the portal document for uncategorized core APIs
- `doc-openapi-ilm-core` — the aggregate the frontend generates its client from

## Verification

`mvn verify -DapiVersion=2.20.0-SNAPSHOT` against a locally installed `interfaces` snapshot built from the companion branch:

- `/v1/branding` present in both documents, with no security requirement and no 401/403 responses, confirming `NoAuthController` was resolved correctly
- `redocly lint` clean on both — the 6 remaining warnings are pre-existing ambiguous-path findings unrelated to this change

## Sequencing

**Merge after OmniTrustILM/interfaces#868.** CI resolves `interfaces` from the published snapshot, so generation fails here until `BrandingController` exists on that side.



Closes OmniTrustILM/interface-documentation#241
