### PR TITLE
Add Cryptography Provider v2 OpenAPI group

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -168,6 +168,23 @@ groups:
       - com.otilm.api.interfaces.connector.cryptography.KeyManagementController
       - com.otilm.api.interfaces.connector.cryptography.TokenInstanceController
 
+  - id: doc-openapi-connector-cryptography-provider-v2
+    groupName: connector-cryptography-provider-v2
+    title: Cryptography Provider v2 API
+    indexCategory: connector
+    description: REST API for implementations of custom v2 Cryptography Provider
+    serverUrl: https://demo.otilm.com
+    extensions:
+      x-metrics-profile: "`com.otilm.api.interfaces.connector.common.v2.MetricsController.METRICS_CONFIG`"
+    interfaces:
+      - com.otilm.api.interfaces.connector.common.v2.AttributesController
+      - com.otilm.api.interfaces.connector.common.v2.HealthController
+      - com.otilm.api.interfaces.connector.common.v2.InfoController
+      - com.otilm.api.interfaces.connector.common.v2.MetricsController
+      - com.otilm.api.interfaces.connector.cryptography.v2.CryptographicOperationsController
+      - com.otilm.api.interfaces.connector.cryptography.v2.KeyController
+      - com.otilm.api.interfaces.connector.cryptography.v2.TokenController
+
   - id: doc-openapi-connector-discovery-provider
     groupName: connector-discovery-provider
     title: Discovery Provider API

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <revision>2.19.0</revision>
-        <apiVersion>2.19.0</apiVersion>
+        <apiVersion>2.20.0-SNAPSHOT</apiVersion>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <revision>2.19.0</revision>
+        <revision>2.20.0-SNAPSHOT</revision>
         <apiVersion>2.20.0-SNAPSHOT</apiVersion>
 
         <!-- Plugin versions -->


### PR DESCRIPTION
## What

Publishes the v2 Cryptography Provider connector API as its own documentation group, `connector-cryptography-provider-v2`, alongside the common v2 info, health, metrics and attributes surface. The group mirrors `connector-authority-provider-v3`, including the `x-metrics-profile` extension.

The generated document covers 32 paths and 157 schemas: the 24 cryptography v2 endpoints (5 token, 7 key, 12 operations) plus the common connector surface.

## Verification

Built locally with the `com.otilm:interfaces` artifact purged from the local repository, so it resolved from the remote snapshot repository:

```
Downloaded: interfaces-2.20.0-20260815.093152-17.jar (2.3 MB)
✅ Successfully generated 101 dummy controller classes
Registered OpenAPI group: connector-cryptography-provider-v2 (7 interfaces)
✓ Generated: openapi/doc-openapi-connector-cryptography-provider-v2.yaml
BUILD SUCCESS
```

