### PR TITLE
Add Comments API OpenAPI group

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -338,6 +338,14 @@ groups:
     interfaces:
       - com.otilm.api.interfaces.core.web.CmpProfileController
 
+  - id: doc-openapi-core-comment
+    groupName: core-comment
+    title: Comments API
+    indexCategory: core
+    description: REST API for managing comments on objects in the platform
+    interfaces:
+      - com.otilm.api.interfaces.core.web.CommentController
+
   - id: doc-openapi-core-compliance-profile
     groupName: core-compliance-profile
     title: Compliance Profile API
@@ -604,6 +612,7 @@ groups:
       - com.otilm.api.interfaces.core.web.CbomController
       - com.otilm.api.interfaces.core.web.CertificateController
       - com.otilm.api.interfaces.core.web.CmpProfileController
+      - com.otilm.api.interfaces.core.web.CommentController
       - com.otilm.api.interfaces.core.web.ComplianceProfileController
       - com.otilm.api.interfaces.core.web.ConnectorAuthController
       - com.otilm.api.interfaces.core.web.ConnectorController


### PR DESCRIPTION
Closes #226

Registers `CommentController` (OmniTrustILM/interfaces#882, merged) in the spec generation, so the comment endpoints, DTOs and enum additions reach the published specs — including the one the administrator UI generates its client from. Epic: OmniTrustILM/ilm#246.

## What's here

`groups.yaml` only, following the precedent of #206 and #238:

- a new `doc-openapi-core-comment` group ("Comments API"), sized like the other single-controller core groups such as `core-signing-record`;
- `CommentController` added to the aggregate `doc-openapi-ilm-core` group.

## Verification

`mvn verify` regenerates the specs; the new `openapi/doc-openapi-core-comment.yaml` contains all five endpoints (`listComments`, `createComment`, `listReplies`, `resolveComment`, `unresolveComment`), the `CommentDto`/`CommentCreateRequestDto`/`CommentResponseDto` models, and renders `comments` in the `Resource` enum. The comment paths also appear in `doc-openapi-ilm-core.yaml`. `redocly lint` is clean on the new spec and on the aggregate.

One note: the aggregate spec gains a seventh `no-ambiguous-paths` warning, because `/v1/comments/{resource}/{objectUuid}` overlaps in shape with the pre-existing `/v1/{resource}/{parentObjectUuid}/callback`. It is a warning rather than an error (lint still exits 0, as it already does for the six existing instances) and cannot be hit in practice — the third segment is a UUID, never the literal `callback`, and the literal prefix wins in path matching.