### PR TITLE
Publish the list view API in the core OpenAPI groups

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -462,6 +462,7 @@ groups:
       - com.otilm.api.interfaces.core.web.CustomOidEntryController
       - com.otilm.api.interfaces.core.web.EnumController
       - com.otilm.api.interfaces.core.web.InfoController
+      - com.otilm.api.interfaces.core.web.ListViewController
       - com.otilm.api.interfaces.core.web.ResourceController
       - com.otilm.api.interfaces.core.web.SettingController
       - com.otilm.api.interfaces.core.web.StatisticsController
@@ -628,6 +629,7 @@ groups:
       - com.otilm.api.interfaces.core.web.GlobalMetadataController
       - com.otilm.api.interfaces.core.web.GroupController
       - com.otilm.api.interfaces.core.web.InfoController
+      - com.otilm.api.interfaces.core.web.ListViewController
       - com.otilm.api.interfaces.core.web.LocationManagementController
       - com.otilm.api.interfaces.core.web.NotificationController
       - com.otilm.api.interfaces.core.web.NotificationInstanceController


### PR DESCRIPTION
Adds `com.otilm.api.interfaces.core.web.ListViewController` to the `core-other` group and to the `ilm-core` aggregate.

`ListViewController` is the saved-list-view CRUD contract added in OmniTrustILM/interfaces#891. Controllers are enumerated per group by hand, so without an entry here `/v1/listViews` never reaches a generated OpenAPI document and no client is generated for it.

`core-other` is the home for the cross-cutting platform APIs (`ResourceController`, `SettingController`, `EnumController`), which is what a per-user view preference is.

CI will stay red until OmniTrustILM/interfaces#891 merges and the `2.20.0-SNAPSHOT` artifact carries the controller.