### PR TITLE
Add Discovery Provider v2 OpenAPI group

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -197,6 +197,22 @@ groups:
       - com.otilm.api.interfaces.connector.HealthController
       - com.otilm.api.interfaces.connector.InfoController
 
+  - id: doc-openapi-connector-discovery-provider-v2
+    groupName: connector-discovery-provider-v2
+    title: Discovery Provider v2 API
+    indexCategory: connector
+    description: REST API for implementations of custom v2 Discovery Provider
+    serverUrl: https://demo.otilm.com
+    extensions:
+      x-metrics-profile: "`com.otilm.api.interfaces.connector.common.v2.MetricsController.METRICS_CONFIG`"
+    interfaces:
+      - com.otilm.api.interfaces.connector.common.v2.AttributesController
+      - com.otilm.api.interfaces.connector.common.v2.HealthController
+      - com.otilm.api.interfaces.connector.common.v2.InfoController
+      - com.otilm.api.interfaces.connector.common.v2.MetricsController
+      - com.otilm.api.interfaces.connector.discovery.v2.DiscoveryMetadataController
+      - com.otilm.api.interfaces.connector.discovery.v2.DiscoveryOperationController
+
   - id: doc-openapi-connector-entity-provider
     groupName: connector-entity-provider
     title: Entity Provider API


### PR DESCRIPTION
## TLDR

Publishes the Discovery Provider v2 connector API on the interface documentation site, as a group mirroring the Authority Provider v3 block. Sixteen lines in `groups.yaml`; the v1 discovery group is untouched and stays until sunset.

Closes #219.

## Why now

interfaces#912 merged, so the contract this documents is on `main`. Two things worth knowing about what that did and did not leave to do:

- **The Core-side OpenAPI is already published.** The `Generate OpenAPI Docs` workflow republished after #912 merged, so `doc-openapi-ilm-core.yaml` already carries `GET /v1/discoveries/{uuid}/messages`, `DiscoveryMessageDto`, `runMessageCount` and the corrected `processed`/`processedError` descriptions. Nothing to commit there — `/openapi/` is gitignored and the workflow owns publication.
- **The connector v2 group was never published at all.** That is the real gap this closes: the discovery v2 event schemas (`DiscoveryErrorEvent`, `DiscoveryProgressEvent`, `DiscoveryStateChangedEvent` and the rest) surface publicly here for the first time.

## Verification

- `mvn clean install` green across all six modules; generates `doc-openapi-connector-discovery-provider-v2.yaml` with 18 paths — the seven lifecycle operations, three metadata operations, and the common v2 attributes/health/info/metrics.
- `./lint.sh` exits 0 with zero warnings on the new document; `redocly build-docs` renders it.
- The generated index places **Discovery Provider v2** in the connector category beside Authority Provider v3.
- FE type generation checked against fe-administrator's own `openapitools.json` settings (openapi-generator 7.12.0, `typescript-rxjs`): it emits `DiscoveryMessageDto`, `DiscoveryMessageSeverity`, `PaginationResponseDtoDiscoveryMessageDto`, `getDiscoveryRunMessages()`, `runMessageCount: number` with `runMessages` gone, and `DiscoveryStatus` carrying `Stopped`/`Cancelled`.

## Two things for the reviewer to decide

**1. The changelog note has nowhere to live.** #219 asks for one, but no `CHANGELOG.md` exists in this repo — or in `core`, `interfaces`, `go-sdk`, `fe-administrator` or `documentation`. Release notes are generated from PR titles via `.github/release.yml`. Rather than invent a file convention no release process reads, here is the text for whoever assembles the 2.20.0 notes:

> **Discovery API — `DiscoveryStatus` gains `stopped` and `cancelled`**
> Discovery v2 adds stop/resume and cancel, so `DiscoveryStatus` now carries two values beyond `inProgress`, `processing`, `failed`, `completed` and `warning`. Clients that switch exhaustively over the enum, or validate it against a closed list, need tolerant-reader behaviour — treat an unrecognised status as unknown rather than failing the response.
>
> **Discovery API — `runMessages` removed from `DiscoveryDetailDto`**
> The run's advisory log moved to its own paged resource, `GET /v1/discoveries/{uuid}/messages`, and the detail now carries `runMessageCount` instead. This is source-breaking for anyone consuming the generated types.

**2. `runMessages` being removed is the harder break** of the two and is not in #219's scope list, so it is above rather than assumed. Worth confirming it belongs in the same note.
