### PR TITLE
Fix lint failure from redocly 2.49.0 and openssl CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN for file in /home/app/*.yaml; do redocly build-docs "$file" -o "${file/yaml/
 
 # production environment
 FROM nginx:stable-alpine
+
+# Patch base-image OS packages for known CVEs (openssl CVE-2026-14456).
+# Pin the minimum fixed version so the build fails fast if the patched package
+# is ever unavailable, keeping the Trivy scan gate reliably green.
+RUN apk add --no-cache --upgrade "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
+
 COPY --from=build /home/app/index.html /usr/share/nginx/html/docs/index.html
 COPY --from=build /home/app/style.css /usr/share/nginx/html/docs/style.css
 COPY --from=build /home/app/images/ilm-logo.svg /usr/share/nginx/html/docs/images/ilm-logo.svg

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ RUN for file in /home/app/*.yaml; do redocly build-docs "$file" -o "${file/yaml/
 # production environment
 FROM nginx:stable-alpine
 
-# Patch base-image OS packages for known CVEs (openssl CVE-2026-14456).
-# Pin the minimum fixed version so the build fails fast if the patched package
-# is ever unavailable, keeping the Trivy scan gate reliably green.
+# Patch base-image openssl for CVE-2026-14456. The pinned minimum makes the
+# build fail fast if the fixed package ever goes missing, keeping Trivy green.
 RUN apk add --no-cache --upgrade "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
 
 COPY --from=build /home/app/index.html /usr/share/nginx/html/docs/index.html

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -3,10 +3,7 @@ extends:
 
 rules:
   no-ambiguous-paths: warn
-  # The attribute content schemas (BaseAttributeContentDtoV2, DataAttribute,
-  # MetadataAttribute, CustomAttribute) model their variants as a bare `oneOf`
-  # in which every branch shares `reference` and `data`, so no branch excludes
-  # another. The real fix is a discriminator on the generating types in the
-  # interfaces repo; until that lands, warn rather than fail the build on
-  # generated output this repository does not own.
+  # Attribute content schemas such as BaseAttributeContentDtoV2 use a bare `oneOf`
+  # whose branches all share `reference` and `data`, so none excludes the others.
+  # Needs a discriminator in the interfaces repo; generated here, so warn only.
   no-illogical-composition-keywords: warn

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -3,3 +3,10 @@ extends:
 
 rules:
   no-ambiguous-paths: warn
+  # The attribute content schemas (BaseAttributeContentDtoV2, DataAttribute,
+  # MetadataAttribute, CustomAttribute) model their variants as a bare `oneOf`
+  # in which every branch shares `reference` and `data`, so no branch excludes
+  # another. The real fix is a discriminator on the generating types in the
+  # interfaces repo; until that lands, warn rather than fail the build on
+  # generated output this repository does not own.
+  no-illogical-composition-keywords: warn

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -5,5 +5,6 @@ rules:
   no-ambiguous-paths: warn
   # Attribute content schemas such as BaseAttributeContentDtoV2 use a bare `oneOf`
   # whose branches all share `reference` and `data`, so none excludes the others.
-  # Needs a discriminator in the interfaces repo; generated here, so warn only.
+  # V3 solves this with a required `contentType` discriminator; V2 cannot gain one
+  # without breaking existing clients, so warn here until V2 sunsets.
   no-illogical-composition-keywords: warn


### PR DESCRIPTION
## TLDR

Two unrelated CI failures, both from upstream drift rather than any change in this repo. Redocly CLI 2.49.0 (published today) adds a lint rule that fails every generated OpenAPI document, and the `nginx:stable-alpine` base picked up a HIGH openssl CVE. This downgrades the rule to a warning and patches the base packages.

## Redocly lint

`build.yml` installs `@redocly/cli` unpinned. Today's run picked up 2.49.0, published 22 minutes before the job started. That release adds `no-illogical-composition-keywords` at error severity in `recommended-strict`.

The result is 1441 errors across all 60 documents in `openapi/`, every one of them from that single rule.

What the rule flags is real. `BaseAttributeContentDtoV2` (1421 of the errors), plus `DataAttribute`, `MetadataAttribute` and `CustomAttribute`, model their variants as a bare `oneOf` in which every branch carries `reference` and `data` and nothing distinguishes them. The proper fix is a discriminator on the generating types in `interfaces`. These documents are generated here rather than authored, so this repo cannot fix them — hence `warn`, matching the existing `no-ambiguous-paths: warn` precedent.

Verified: `lint.sh` on 2.49.0 across all 60 files exits 0, with no errors from any rule.

## openssl CVE

`nginx:stable-alpine` (alpine 3.24.1) ships libcrypto3 and libssl3 at 3.5.7-r0. CVE-2026-14456 is HIGH and fixed in 3.5.8-r0, so the org Trivy policy gates on it correctly. The base image was last rebuilt on 2026-07-18, so it will not self-heal soon.

This follows the pattern already in `fe-administrator`: `apk add --no-cache --upgrade` with pinned minimums, so the build fails fast if a patched package ever disappears. Switching to bare `alpine:3.24` (as `core` does) was considered and rejected — `core` jlinks its own JRE and needs only an OS, whereas this image depends on the nginx layout, default config and entrypoint.

Verified by building the production stage in isolation and scanning it with the org policy from `.github/actions/resolve-trivy-config/trivy.yaml`:

- unpatched base: exit 1, `Total: 2 (HIGH: 2, CRITICAL: 0)` — reproduces the CI failure
- patched: exit 0, 0 vulnerabilities

## Worth a follow-up

`fe-administrator` is failing on this same CVE right now; its pin list covers c-ares and curl but not libcrypto3/libssl3.

The unpinned `yarn global add @redocly/cli` in `build.yml`, and `npm install -g @redocly/cli` in the Dockerfile, will keep letting releases land mid-PR. Pinning both is worth doing separately.
